### PR TITLE
fix: Crash on accepted sockets when peer disconnects before address gathering

### DIFF
--- a/lib/socket-duplex.js
+++ b/lib/socket-duplex.js
@@ -684,6 +684,11 @@ const create = ({
     duplex.emit("peer-info-update");
   };
 
+  // Seed with initial remote address so the "keep the last state" fallback
+  // in determineRemoteAddressesToUse has valid state on the first call
+  duplex.remoteAddress = initialRemoteAddress.address;
+  duplex.remoteAddresses = [initialRemoteAddress.address];
+
   updateAddressProperties();
 
   const updateAddressIntervalHandle = setInterval(() => {


### PR DESCRIPTION
`createServer` crashes with `TypeError: Cannot read properties of undefined (reading 'forEach')` when the peer closes the connection before `sctp_getpaddrs()` runs on the accepted fd.

**Root cause**

Race condition in `socket-duplex.js`. On accept, `updateAddressProperties()` fires immediately (L687). If the peer has already disconnected, `sctp_getpaddrs()` returns `ENOTCONN`/`EINVAL`, so `getRemoteAddresses()` returns `undefined`. `determineRemoteAddressesToUse()` falls through to the "keep last state" path (L609) and returns `duplex.remoteAddresses` - but on the first call that property was never initialized, so `remoteAddresses.forEach(…)` at L670 throws.

Any fire-and-forget client (send and close with no wait response) can trigger this if the close reaches the kernel before lksctp's poll callback creates the duplex socket.

Tested on Node v25.6.1, Linux 6.18.9, libsctp 1.0.19.

**Fix**
Seed `duplex.remoteAddress` and `duplex.remoteAddresses` with `initialRemoteAddress` before the first `updateAddressProperties()` call, so the "keep last state" fallback always has valid state:

Similar to how the `!connected` branch (L577–582) already handles unknown remote addresses. When `sctp_getpaddrs` succeeds the seed is immediately overwritten (L666–667), so this only affects the failure path.